### PR TITLE
Expose disks via NBD and creation of "empty" VMs

### DIFF
--- a/ovc/accounts.go
+++ b/ovc/accounts.go
@@ -3,7 +3,6 @@ package ovc
 import (
 	"encoding/json"
 	"errors"
-	"net/http"
 )
 
 // Account contains
@@ -59,11 +58,7 @@ func (s *AccountServiceOp) GetIDByName(account string) (int, error) {
 
 // List all accounts
 func (s *AccountServiceOp) List() (*AccountList, error) {
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/accounts/list", nil)
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.PostRaw("/cloudapi/accounts/list", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ovc/client.go
+++ b/ovc/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -311,4 +312,24 @@ func jwtFromIYO(c *Config) (string, error) {
 	}
 
 	return bodyStr, nil
+}
+
+// PostRaw POSTs a request with `raw` as data (nil is permitted) to `c.ServerUrl + endpoint`
+func (c *Client) PostRaw(endpoint string, raw io.Reader) ([]byte, error) {
+	req, err := http.NewRequest("POST", c.ServerURL+endpoint, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req)
+}
+
+// Post marshals `in` to JSON and POSTs a request to `c.ServerUrl + endpoint`
+func (c *Client) Post(endpoint string, in interface{}) ([]byte, error) {
+	jsonIn, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.PostRaw(endpoint, bytes.NewBuffer(jsonIn))
 }

--- a/ovc/cloudspaces.go
+++ b/ovc/cloudspaces.go
@@ -1,10 +1,8 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"net/http"
 	"strconv"
 )
 
@@ -124,15 +122,7 @@ type CloudSpaceServiceOp struct {
 func (s *CloudSpaceServiceOp) List() (*CloudSpaceList, error) {
 	cloudSpaceMap := make(map[string]interface{})
 	cloudSpaceMap["includedeleted"] = false
-	cloudSpaceJSON, err := json.Marshal(cloudSpaceMap)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/cloudspaces/list", bytes.NewBuffer(cloudSpaceJSON))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/cloudspaces/list", cloudSpaceMap)
 	if err != nil {
 		return nil, err
 	}
@@ -154,15 +144,8 @@ func (s *CloudSpaceServiceOp) Get(cloudSpaceID string) (*CloudSpace, error) {
 		return nil, err
 	}
 	cloudSpaceIDMap["cloudspaceId"] = cloudSpaceIDInt
-	cloudSpaceIDJson, err := json.Marshal(cloudSpaceIDMap)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/cloudspaces/get", bytes.NewBuffer(cloudSpaceIDJson))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+
+	body, err := s.client.Post("/cloudapi/cloudspaces/get", cloudSpaceIDMap)
 	if err != nil {
 		return nil, err
 	}
@@ -193,15 +176,7 @@ func (s *CloudSpaceServiceOp) GetByNameAndAccount(cloudSpaceName string, account
 
 // Create a new CloudSpace
 func (s *CloudSpaceServiceOp) Create(cloudSpaceConfig *CloudSpaceConfig) (string, error) {
-	cloudSpaceJSON, err := json.Marshal(*cloudSpaceConfig)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/cloudspaces/create", bytes.NewBuffer(cloudSpaceJSON))
-	if err != nil {
-		return "", err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/cloudspaces/create", *cloudSpaceConfig)
 	if err != nil {
 		return "", err
 	}
@@ -211,31 +186,13 @@ func (s *CloudSpaceServiceOp) Create(cloudSpaceConfig *CloudSpaceConfig) (string
 
 // Delete a CloudSpace
 func (s *CloudSpaceServiceOp) Delete(cloudSpaceConfig *CloudSpaceDeleteConfig) error {
-	cloudSpaceJSON, err := json.Marshal(*cloudSpaceConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/cloudspaces/delete", bytes.NewBuffer(cloudSpaceJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/cloudspaces/delete", *cloudSpaceConfig)
 	return err
 }
 
 // Update an existing CloudSpace
 func (s *CloudSpaceServiceOp) Update(cloudSpaceConfig *CloudSpaceConfig) error {
-	cloudSpaceJSON, err := json.Marshal(*cloudSpaceConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/cloudspaces/update", bytes.NewBuffer(cloudSpaceJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/cloudspaces/update", *cloudSpaceConfig)
 	return err
 }
 
@@ -245,15 +202,6 @@ func (s *CloudSpaceServiceOp) SetDefaultGateway(cloudspaceID int, gateway string
 	csMap["cloudspaceId"] = cloudspaceID
 	csMap["gateway"] = gateway
 
-	csMapJSON, err := json.Marshal(csMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/cloudspaces/setDefaultGateway", bytes.NewBuffer(csMapJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/cloudspaces/setDefaultGateway", csMap)
 	return err
 }

--- a/ovc/disks.go
+++ b/ovc/disks.go
@@ -94,6 +94,7 @@ type DiskExposeConfig struct {
 	Protocol     string `json:"-"`
 	DiskID       int    `json:"diskId"`
 	CloudSpaceID int    `json:"cloudspaceId"`
+	IOPS         int    `json:"iops"`
 }
 
 // DiskEndPointDescriptor is an interface that a type representing a storage

--- a/ovc/external_networks.go
+++ b/ovc/external_networks.go
@@ -1,10 +1,8 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 )
 
@@ -53,19 +51,17 @@ type ExternalNetworkServiceOp struct {
 // Get external network
 func (s *ExternalNetworkServiceOp) Get(id string) (*ExternalNetworkInfo, error) {
 	externalNetworkIDMap := make(map[string]interface{})
-	externalNetworkIDMap["id"], _ = strconv.Atoi(id)
-	externalNetworkJSON, err := json.Marshal(externalNetworkIDMap)
+	var err error
+	externalNetworkIDMap["id"], err = strconv.Atoi(id)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/externalnetwork/get", bytes.NewBuffer(externalNetworkJSON))
+
+	body, err := s.client.Post("/cloudapi/externalnetwork/get", externalNetworkIDMap)
 	if err != nil {
 		return nil, err
 	}
-	body, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+
 	externalNetworkInfo := new(ExternalNetworkInfo)
 	err = json.Unmarshal(body, &externalNetworkInfo)
 	if err != nil {
@@ -98,19 +94,12 @@ func (s *ExternalNetworkServiceOp) GetByName(name string, accountID string) (*Ex
 func (s *ExternalNetworkServiceOp) List(accountID int) (*ExternalNetworkList, error) {
 	accountIDMap := make(map[string]interface{})
 	accountIDMap["accountId"] = accountID
-	accountIDJson, err := json.Marshal(accountIDMap)
+
+	body, err := s.client.Post("/cloudapi/externalnetwork/list", accountIDMap)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/externalnetwork/list", bytes.NewBuffer(accountIDJson))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
 	externalNetworks := new(ExternalNetworkList)
 	err = json.Unmarshal(body, &externalNetworks)
 	if err != nil {

--- a/ovc/forwarding.go
+++ b/ovc/forwarding.go
@@ -1,11 +1,9 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"strconv"
 	"time"
 )
@@ -95,15 +93,8 @@ func (s *ForwardingServiceOp) Create(portForwardingConfig *PortForwardingConfig)
 	if portForwardingConfig.PublicPort == 0 {
 		portForwardingConfig.PublicPort = s.getRandomPublicPort(portForwardingConfig)
 	}
-	portForwardingJSON, err := json.Marshal(*portForwardingConfig)
-	if err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/portforwarding/create", bytes.NewBuffer(portForwardingJSON))
-	if err != nil {
-		return 0, err
-	}
-	_, err = s.client.Do(req)
+
+	_, err := s.client.Post("/cloudapi/portforwarding/create", *portForwardingConfig)
 	if err != nil {
 		return 0, err
 	}
@@ -113,48 +104,23 @@ func (s *ForwardingServiceOp) Create(portForwardingConfig *PortForwardingConfig)
 
 // Update an existing portforward
 func (s *ForwardingServiceOp) Update(portForwardingConfig *PortForwardingConfig) error {
-	portForwardingJSON, err := json.Marshal(*portForwardingConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/portforwarding/updateByPort", bytes.NewBuffer(portForwardingJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/portforwarding/updateByPort", *portForwardingConfig)
 	return err
 }
 
 // Delete an existing portforward
 func (s *ForwardingServiceOp) Delete(portForwardingConfig *PortForwardingConfig) error {
-	portForwardingJSON, err := json.Marshal(*portForwardingConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/portforwarding/deleteByPort", bytes.NewBuffer(portForwardingJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/portforwarding/deleteByPort", *portForwardingConfig)
 	return err
 }
 
 // List all portforwards
 func (s *ForwardingServiceOp) List(portForwardingConfig *PortForwardingConfig) (*PortForwardingList, error) {
-	portForwardingJSON, err := json.Marshal(*portForwardingConfig)
+	body, err := s.client.Post("/cloudapi/portforwarding/list", *portForwardingConfig)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/portforwarding/list", bytes.NewBuffer(portForwardingJSON))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+
 	portForwardingList := new(PortForwardingList)
 	err = json.Unmarshal(body, &portForwardingList)
 	if err != nil {
@@ -170,16 +136,8 @@ func (s *ForwardingServiceOp) DeleteByPort(publicPort int, publicIP string, clou
 	pfMap["publicIp"] = publicIP
 	pfMap["publicPort"] = publicPort
 	pfMap["cloudspaceId"] = cloudSpaceID
-	pfJSON, err := json.Marshal(pfMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/portforwarding/deleteByPort", bytes.NewBuffer(pfJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudapi/portforwarding/deleteByPort", pfMap)
 	return err
 }
 

--- a/ovc/images.go
+++ b/ovc/images.go
@@ -1,9 +1,7 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
 )
 
 // ImageConfig is used when uploading an image
@@ -51,20 +49,8 @@ type ImageServiceOp struct {
 
 // Upload uploads an image to the system API
 func (s *ImageServiceOp) Upload(imageConfig *ImageConfig) error {
-	imageJSON, err := json.Marshal(*imageConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudbroker/image/createImage", bytes.NewBuffer(imageJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := s.client.Post("/cloudbroker/image/createImage", *imageConfig)
+	return err
 }
 
 // DeleteByID deletes an existing image by ID
@@ -72,16 +58,8 @@ func (s *ImageServiceOp) DeleteByID(imageID int) error {
 	imageMap := make(map[string]interface{})
 	imageMap["imageId"] = imageID
 	imageMap["permanently"] = true
-	imageJSON, err := json.Marshal(imageMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/images/delete", bytes.NewBuffer(imageJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudapi/images/delete", imageMap)
 	return err
 }
 
@@ -91,16 +69,8 @@ func (s *ImageServiceOp) DeleteSystemImageByID(imageID int, reason string) error
 	imageMap["imageId"] = imageID
 	imageMap["reason"] = reason
 	imageMap["permanently"] = true
-	imageJSON, err := json.Marshal(imageMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudbroker/image/delete", bytes.NewBuffer(imageJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudbroker/image/delete", imageMap)
 	return err
 }
 
@@ -108,16 +78,8 @@ func (s *ImageServiceOp) DeleteSystemImageByID(imageID int, reason string) error
 func (s *ImageServiceOp) List(accountID int) (*ImageList, error) {
 	accountIDMap := make(map[string]interface{})
 	accountIDMap["accountId"] = accountID
-	accountIDJson, err := json.Marshal(accountIDMap)
-	if err != nil {
-		return nil, err
-	}
 
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/images/list", bytes.NewBuffer(accountIDJson))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/images/list", accountIDMap)
 	if err != nil {
 		return nil, err
 	}

--- a/ovc/ipsec.go
+++ b/ovc/ipsec.go
@@ -1,9 +1,7 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
 )
 
 // IpsecConfig is used when creating/deleting/listing ipsec
@@ -38,15 +36,7 @@ type IpsecServiceOp struct {
 
 // Create a new ipsec tunnel
 func (s *IpsecServiceOp) Create(ipsecConfig *IpsecConfig) (string, error) {
-	ipsecJSON, err := json.Marshal(*ipsecConfig)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/ipsec/addTunnelToCloudspace", bytes.NewBuffer(ipsecJSON))
-	if err != nil {
-		return "", err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/ipsec/addTunnelToCloudspace", *ipsecConfig)
 	if err != nil {
 		return "", err
 	}
@@ -62,30 +52,13 @@ func (s *IpsecServiceOp) Create(ipsecConfig *IpsecConfig) (string, error) {
 
 // Delete an existing ipsec tunnel
 func (s *IpsecServiceOp) Delete(ipsecConfig *IpsecConfig) error {
-	ipsecJSON, err := json.Marshal(*ipsecConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/ipsec/removeTunnelFromCloudspace", bytes.NewBuffer(ipsecJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/ipsec/removeTunnelFromCloudspace", *ipsecConfig)
 	return err
 }
 
 // List all ipsec of a cloudspace
 func (s *IpsecServiceOp) List(ipsecConfig *IpsecConfig) (*IpsecList, error) {
-	ipsecJSON, err := json.Marshal(*ipsecConfig)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/ipsec/listTunnels", bytes.NewBuffer(ipsecJSON))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/ipsec/listTunnels", *ipsecConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/ovc/jwt_test.go
+++ b/ovc/jwt_test.go
@@ -93,7 +93,7 @@ func TestGetClaim(t *testing.T) {
 
 func TestIsExpired(t *testing.T) {
 	log := logrus.New()
-	logger := log.WithField("source", "OpenvCloud client JWT manager test")
+	logger := LogrusAdapter{log.WithField("source", "OpenvCloud client JWT manager test")}
 
 	// Expired an hour ago
 	tokenStr, err := createJWT(t, -time.Hour, "", nil)

--- a/ovc/locations.go
+++ b/ovc/locations.go
@@ -2,7 +2,6 @@ package ovc
 
 import (
 	"encoding/json"
-	"net/http"
 )
 
 // LocationService represents Location service interface
@@ -31,11 +30,7 @@ type LocationList []LocationInfo
 
 // List lists all locations of the G8
 func (s *LocationServiceOp) List() (*LocationList, error) {
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/locations/list", nil)
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.PostRaw("/cloudapi/locations/list", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ovc/logger.go
+++ b/ovc/logger.go
@@ -1,0 +1,24 @@
+package ovc
+
+// Logger describes the logging interface. Essentially a trimmed down version of
+// logrus' FieldLogger, fixing up the With* methods to return a Logger interface
+// instead of a concrete type (*logrus.Entry).
+type Logger interface {
+	WithField(key string, value interface{}) Logger
+	WithFields(fields map[string]interface{}) Logger
+	WithError(err error) Logger
+
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Panicf(format string, args ...interface{})
+
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Warn(args ...interface{})
+	Error(args ...interface{})
+	Fatal(args ...interface{})
+	Panic(args ...interface{})
+}

--- a/ovc/logrus_adapter.go
+++ b/ovc/logrus_adapter.go
@@ -1,0 +1,25 @@
+package ovc
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// LogrusAdapter adapts a logrus.FieldLogger to the Logger interface
+type LogrusAdapter struct {
+	logrus.FieldLogger
+}
+
+// WithField implements the eponymous method of Logger
+func (l LogrusAdapter) WithField(key string, value interface{}) Logger {
+	return LogrusAdapter{l.FieldLogger.WithField(key, value)}
+}
+
+// WithFields implements the eponymous method of Logger
+func (l LogrusAdapter) WithFields(fields map[string]interface{}) Logger {
+	return LogrusAdapter{l.FieldLogger.WithFields(fields)}
+}
+
+// WithError implements the eponymous method of Logger
+func (l LogrusAdapter) WithError(err error) Logger {
+	return LogrusAdapter{l.FieldLogger.WithError(err)}
+}

--- a/ovc/machines.go
+++ b/ovc/machines.go
@@ -1,10 +1,8 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 )
 
@@ -135,18 +133,12 @@ type MachineServiceOp struct {
 func (s *MachineServiceOp) List(cloudSpaceID int) (*MachineList, error) {
 	cloudSpaceIDMap := make(map[string]interface{})
 	cloudSpaceIDMap["cloudspaceId"] = cloudSpaceID
-	cloudSpaceIDJSON, err := json.Marshal(cloudSpaceIDMap)
+
+	body, err := s.client.Post("/cloudapi/machines/list", cloudSpaceIDMap)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/list", bytes.NewBuffer(cloudSpaceIDJSON))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+
 	machines := new(MachineList)
 	err = json.Unmarshal(body, &machines)
 	if err != nil {
@@ -159,19 +151,17 @@ func (s *MachineServiceOp) List(cloudSpaceID int) (*MachineList, error) {
 // Get individual machine
 func (s *MachineServiceOp) Get(id string) (*MachineInfo, error) {
 	machineIDMap := make(map[string]interface{})
-	machineIDMap["machineId"], _ = strconv.Atoi(id)
-	machineIDJson, err := json.Marshal(machineIDMap)
+	var err error
+	machineIDMap["machineId"], err = strconv.Atoi(id)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/get", bytes.NewBuffer(machineIDJson))
+
+	body, err := s.client.Post("/cloudapi/machines/get", machineIDMap)
 	if err != nil {
 		return nil, err
 	}
-	body, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+
 	machineInfo := new(MachineInfo)
 	err = json.Unmarshal(body, &machineInfo)
 	if err != nil {
@@ -204,16 +194,8 @@ func (s *MachineServiceOp) GetByName(name string, cloudspaceID string) (*Machine
 func (s *MachineServiceOp) GetByReferenceID(referenceID string) (*MachineInfo, error) {
 	referenceIDMap := make(map[string]interface{})
 	referenceIDMap["referenceId"] = referenceID
-	referenceIDJson, err := json.Marshal(referenceIDMap)
-	if err != nil {
-		return nil, err
-	}
 
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/getByReferenceId", bytes.NewBuffer(referenceIDJson))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/machines/getByReferenceId", referenceIDMap)
 	if err != nil {
 		return nil, err
 	}
@@ -223,15 +205,7 @@ func (s *MachineServiceOp) GetByReferenceID(referenceID string) (*MachineInfo, e
 
 // Create a new machine
 func (s *MachineServiceOp) Create(machineConfig *MachineConfig) (string, error) {
-	machineJSON, err := json.Marshal(*machineConfig)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/create", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return "", err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/machines/create", *machineConfig)
 	if err != nil {
 		return "", err
 	}
@@ -241,15 +215,7 @@ func (s *MachineServiceOp) Create(machineConfig *MachineConfig) (string, error) 
 
 // Update an existing machine
 func (s *MachineServiceOp) Update(machineConfig *MachineConfig) (string, error) {
-	machineJSON, err := json.Marshal(*machineConfig)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/update", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return "", err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/machines/update", *machineConfig)
 	if err != nil {
 		return "", err
 	}
@@ -259,15 +225,7 @@ func (s *MachineServiceOp) Update(machineConfig *MachineConfig) (string, error) 
 
 // Resize an existing machine
 func (s *MachineServiceOp) Resize(machineConfig *MachineConfig) (string, error) {
-	machineJSON, err := json.Marshal(*machineConfig)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/resize", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return "", err
-	}
-	body, err := s.client.Do(req)
+	body, err := s.client.Post("/cloudapi/machines/resize", *machineConfig)
 	if err != nil {
 		return "", err
 	}
@@ -277,16 +235,7 @@ func (s *MachineServiceOp) Resize(machineConfig *MachineConfig) (string, error) 
 
 // Delete an existing machine
 func (s *MachineServiceOp) Delete(machineConfig *MachineConfig) error {
-	machineJSON, err := json.Marshal(*machineConfig)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/delete", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/machines/delete", *machineConfig)
 	return err
 }
 
@@ -295,16 +244,8 @@ func (s *MachineServiceOp) DeleteByID(machineID int) error {
 	machineMap := make(map[string]interface{})
 	machineMap["machineId"] = machineID
 	machineMap["permanently"] = true
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/delete", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudapi/machines/delete", machineMap)
 	return err
 }
 
@@ -313,15 +254,8 @@ func (s *MachineServiceOp) Stop(machineID int, force bool) error {
 	machineMap := make(map[string]interface{})
 	machineMap["machineId"] = machineID
 	machineMap["stop"] = force
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/stop", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
+
+	_, err := s.client.Post("/cloudapi/machines/stop", machineMap)
 	return err
 }
 
@@ -332,15 +266,8 @@ func (s *MachineServiceOp) Start(machineID int, diskID int) error {
 	if diskID != 0 {
 		machineMap["diskId"] = diskID
 	}
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/start", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
+
+	_, err := s.client.Post("/cloudapi/machines/start", machineMap)
 	return err
 }
 
@@ -349,16 +276,8 @@ func (s *MachineServiceOp) Template(machineID int, templateName string) error {
 	machineMap := make(map[string]interface{})
 	machineMap["machineId"] = machineID
 	machineMap["templateName"] = templateName
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return nil
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/createTemplate", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudapi/machines/createTemplate", machineMap)
 	return err
 }
 
@@ -367,16 +286,8 @@ func (s *MachineServiceOp) Shutdown(machineID int) error {
 	machineMap := make(map[string]interface{})
 	machineMap["machineId"] = machineID
 	machineMap["force"] = false
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/stop", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudapi/machines/stop", machineMap)
 	return err
 }
 
@@ -387,16 +298,7 @@ func (s *MachineServiceOp) AddExternalIP(machineID int, externalNetworkID int) e
 	if externalNetworkID != 0 {
 		machineMap["externalNetworkId"] = externalNetworkID
 	}
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/attachExternalNetwork", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
-
+	_, err := s.client.Post("/cloudapi/machines/attachExternalNetwork", machineMap)
 	return err
 }
 
@@ -410,15 +312,7 @@ func (s *MachineServiceOp) DeleteExternalIP(machineID int, externalNetworkID int
 			machineMap["externalnetworkip"] = externalNetworkIP
 		}
 	}
-	machineJSON, err := json.Marshal(machineMap)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/machines/detachExternalNetwork", bytes.NewBuffer(machineJSON))
-	if err != nil {
-		return err
-	}
-	_, err = s.client.Do(req)
 
+	_, err := s.client.Post("/cloudapi/machines/detachExternalNetwork", machineMap)
 	return err
 }

--- a/ovc/machines.go
+++ b/ovc/machines.go
@@ -51,6 +51,20 @@ type MachineConfig struct {
 	Userdata     string        `json:"userdata,omitempty"`
 }
 
+// EmptyMachineConfig is used when creating a new "empty" machine.
+// A machine is considered "empty" if it's not created from an
+// existing image.
+type EmptyMachineConfig struct {
+	CloudspaceID int    `json:"cloudspaceId,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Memory       int    `json:"memory,omitempty"`
+	Vcpus        int    `json:"vcpus,omitempty"`
+	Disksize     int    `json:"disksize,omitempty"`
+	DataDisks    []int  `json:"datadisks,omitempty"`
+	Userdata     string `json:"userdata,omitempty"`
+}
+
 // MachineInfo contains all information related to a cloudspace
 type MachineInfo struct {
 	CloudspaceID int    `json:"cloudspaceid"`
@@ -111,6 +125,7 @@ type MachineService interface {
 	GetByName(string, string) (*MachineInfo, error)
 	GetByReferenceID(string) (*MachineInfo, error)
 	Create(*MachineConfig) (string, error)
+	CreateEmpty(*EmptyMachineConfig) (string, error)
 	Update(*MachineConfig) (string, error)
 	Resize(*MachineConfig) (string, error)
 	Delete(*MachineConfig) error
@@ -206,6 +221,16 @@ func (s *MachineServiceOp) GetByReferenceID(referenceID string) (*MachineInfo, e
 // Create a new machine
 func (s *MachineServiceOp) Create(machineConfig *MachineConfig) (string, error) {
 	body, err := s.client.Post("/cloudapi/machines/create", *machineConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// Create a new "empty" machine (= not based on an existing image)
+func (s *MachineServiceOp) CreateEmpty(emptyMachineConfig *EmptyMachineConfig) (string, error) {
+	body, err := s.client.Post("/cloudapi/machines/createEmptyMachine", *emptyMachineConfig)
 	if err != nil {
 		return "", err
 	}

--- a/ovc/sizes.go
+++ b/ovc/sizes.go
@@ -1,10 +1,8 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"net/http"
 )
 
 // SizesList is a list of sizes
@@ -45,15 +43,8 @@ type SizesServiceOp struct {
 func (s *SizesServiceOp) List(cloudspaceID string) (*SizesList, error) {
 	sizesMap := make(map[string]interface{})
 	sizesMap["cloudspaceId"] = cloudspaceID
-	sizesJSON, err := json.Marshal(sizesMap)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/sizes/list", bytes.NewBuffer(sizesJSON))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
+
+	body, err := s.client.Post("/cloudapi/sizes/list", sizesMap)
 	if err != nil {
 		return nil, err
 	}

--- a/ovc/templates.go
+++ b/ovc/templates.go
@@ -1,9 +1,7 @@
 package ovc
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
 )
 
 // TemplateList is a list of templates
@@ -35,18 +33,12 @@ type TemplateServiceOp struct {
 func (s *TemplateServiceOp) List(accountID int) (*TemplateList, error) {
 	templateMap := make(map[string]interface{})
 	templateMap["accountId"] = 4
-	templateJSON, err := json.Marshal(templateMap)
+
+	body, err := s.client.Post("/cloudapi/images/list", templateMap)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", s.client.ServerURL+"/cloudapi/images/list", bytes.NewBuffer(templateJSON))
-	if err != nil {
-		return nil, err
-	}
-	body, err := s.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+
 	templates := new(TemplateList)
 	err = json.Unmarshal(body, &templates)
 	if err != nil {


### PR DESCRIPTION
Add support for the newly introduced cloudapi calls:
* `ovc.DiskService.Expose` to expose a virtual disk via an NBD export, mapped to 
* `ovc.DiskService.Unxpose` to unexpose a disk from NBD
* `ovc.MachineService.CreateEmpty` to create an "empty" VM, i.e. the boot disk is not based on an existing image
.

While at it, the code is also modified to allow consumers to pass in a `Logger` interface instead of using an internal logrus logger  to allow better integration with client applications. For this purpose new calls are introduced that construct `ovc.Client`s and `ovc.JWT`s while keeping the old ones around but deprecating them to maintain API compatibility.